### PR TITLE
Ignore gh action npm cache until there is a dependencies lock file

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,6 +25,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: 'npm'
+          # cache: 'npm'
       - name: Prettier
         run: npx --yes prettier --check .


### PR DESCRIPTION
You cannot use `cache: 'npm'` in GitHub Actions unless you have a dependencies lock file. So, comment it out for now.